### PR TITLE
Assorted Metadata Fixes

### DIFF
--- a/ride/bmfl.json
+++ b/ride/bmfl.json
@@ -21,10 +21,10 @@
                 ["black", "bright_pink", "black"]
             ],
             [
-                ["bordeaux_red", "black", "bordeaux_red"]
+                ["black", "bright_red", "black"]
             ],
             [
-                ["yellow", "grey", "bright_red"]
+                ["white", "aquamarine", "black"]
             ]
         ],
         "cars": {
@@ -33,7 +33,7 @@
             "mass": 710,
             "numSeats": 4,
             "numSeatRows": 2,
-            "frictionSoundId": 57,
+            "frictionSoundId": 2,
             "soundRange": 0,
             "drawOrder": 8,
             "spriteGroups":{
@@ -57,7 +57,6 @@
                 "corkscrews":4,
                 "restraintAnimation": 4
             },
-            "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
             "hasScreamingRiders": true,
             "loadingPositions": [-2, -4, -2, -4]

--- a/ride/bmrb.json
+++ b/ride/bmrb.json
@@ -8,7 +8,7 @@
         "type": "hyper_twister",
         "category": "rollercoaster",
         "noInversions": true,
-        "minCarsPerTrain": 5,
+        "minCarsPerTrain": 3,
         "maxCarsPerTrain": 10,
         "numEmptyCars": 1,
         "tabCar": 1,
@@ -19,16 +19,16 @@
         },
         "carColours": [
             [
-                ["dark_green", "bordeaux_red", "yellow"]
+                ["yellow", "bright_red", "black"]
             ],
             [
-                ["light_purple", "black", "grey"]
+                ["black", "bright_pink", "black"]
             ],
             [
-                ["light_orange", "bordeaux_red", "dark_yellow"]
+                ["light_blue", "white", "black"]
             ],
             [
-                ["bright_red", "light_brown", "black"]
+                ["bright_red", "dark_green", "black"]
             ]
         ],
         "cars": [
@@ -38,7 +38,7 @@
                 "mass": 680,
                 "numSeats": 4,
                 "numSeatRows": 2,
-                "frictionSoundId": 57,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 8,
                 "spriteGroups":{
@@ -56,7 +56,6 @@
                     "slopes8Banked22":4,
                     "restraintAnimation": 4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [-2, -4, -2, -4]
@@ -64,8 +63,8 @@
             {
                 "rotationFrameMask": 15,
                 "spacing": 95876,
-                "mass": 525,
-                "frictionSoundId": 57,
+                "mass": 450,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 8,
                 "spriteGroups":{
@@ -88,7 +87,6 @@
                     "slopes8Banked22":4,
                     "corkscrews":4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true
             }

--- a/ride/bmsd.json
+++ b/ride/bmsd.json
@@ -1,5 +1,5 @@
 {
-    "id": "rctaa.ride.bmsd",
+    "id": "rct1aa.ride.bmsd",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "sourceGame": "rct1aa",
@@ -8,7 +8,7 @@
         "type": "twister_rc",
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
-        "minCarsPerTrain": 5,
+        "minCarsPerTrain": 3,
         "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "tabCar": 1,
@@ -16,23 +16,26 @@
         "maxHeight": 40,
         "carColours": [
             [
-                ["bright_green", "yellow", "yellow"]
+                ["dark_green", "yellow", "black"]
             ],
             [
-                ["bright_red", "white", "light_orange"]
+                ["light_orange", "white", "black"]
             ],
             [
-                ["light_blue", "light_blue", "white"]
+                ["white", "light_blue", "black"]
+            ],
+            [
+                ["light_blue", "bright_red", "black"]
             ]
         ],
         "cars": [
             {
                 "rotationFrameMask": 15,
                 "spacing": 130740,
-                "mass": 650,
+                "mass": 700,
                 "numSeats": 4,
                 "numSeatRows": 2,
-                "frictionSoundId": 57,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 8,
                 "spriteGroups":{
@@ -56,7 +59,6 @@
                     "corkscrews":4,
                     "restraintAnimation": 4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [-2, -4, -2, -4]
@@ -64,8 +66,8 @@
             {
                 "rotationFrameMask": 15,
                 "spacing": 95876,
-                "mass": 525,
-                "frictionSoundId": 57,
+                "mass": 450,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 8,
                 "spriteGroups":{
@@ -88,7 +90,6 @@
                     "slopes8Banked22":4,
                     "corkscrews":4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true
             }

--- a/ride/bmsu.json
+++ b/ride/bmsu.json
@@ -1,5 +1,5 @@
 {
-    "id": "rct1.ride.bmsu",
+    "id": "rct1aa.ride.bmsu",
     "authors": ["Chris Sawyer", "Simon Foster"],
     "version": "1.0",
     "sourceGame": "rct1aa",
@@ -8,7 +8,7 @@
         "type": "twister_rc",
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
-        "minCarsPerTrain": 5,
+        "minCarsPerTrain": 3,
         "maxCarsPerTrain": 9,
         "numEmptyCars": 1,
         "tabCar": 1,
@@ -21,13 +21,13 @@
         "maxHeight": 40,
         "carColours": [
             [
-                ["yellow", "black", "bright_red"]
+                ["bordeaux_red", "yellow", "black"]
             ],
             [
-                ["light_purple", "bordeaux_red", "yellow"]
+                ["dark_green", "light_orange", "black"]
             ],
             [
-                ["light_blue", "black", "teal"]
+                ["dark_purple", "white", "black"]
             ]
         ],
         "cars": [
@@ -37,7 +37,7 @@
                 "mass": 740,
                 "numSeats": 4,
                 "numSeatRows": 2,
-                "frictionSoundId": 57,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 8,
                 "spriteGroups":{
@@ -61,7 +61,6 @@
                     "corkscrews":4,
                     "restraintAnimation": 4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [-2, -4, -2, -4]
@@ -69,8 +68,8 @@
             {
                 "rotationFrameMask": 15,
                 "spacing": 95876,
-                "mass": 525,
-                "frictionSoundId": 57,
+                "mass": 450,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 8,
                 "spriteGroups":{
@@ -93,7 +92,6 @@
                     "slopes8Banked22":4,
                     "corkscrews":4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true
             }

--- a/ride/corkrc.json
+++ b/ride/corkrc.json
@@ -18,20 +18,23 @@
         },
         "carColours": [
             [
-                ["light_blue", "white", "yellow"]
+                ["bright_red", "white", "black"]
             ],
             [
-                ["bright_red", "yellow", "yellow"]
+                ["bordeaux_red", "yellow", "black"]
             ],
             [
-                ["white", "bordeaux_red", "bordeaux_red"]
+                ["dark_green", "yellow", "black"]
+            ],
+            [
+                ["white", "light_blue", "black"]
             ]
         ],
         "cars": [
             {
                 "rotationFrameMask": 15,
                 "spacing": 261480,
-                "mass": 600,
+                "mass": 550,
                 "numSeats": 4,
                 "numSeatRows": 2,
                 "frictionSoundId": 2,
@@ -57,7 +60,6 @@
                     "corkscrews":4,
                     "restraintAnimation": 4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [5, 3, -7, -9]
@@ -65,7 +67,7 @@
             {
                 "rotationFrameMask": 15,
                 "spacing": 226616,
-                "mass": 500,
+                "mass": 525,
                 "numSeats": 4,
                 "numSeatRows": 2,
                 "frictionSoundId": 2,
@@ -91,7 +93,6 @@
                     "corkscrews":4,
                     "restraintAnimation": 4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [7, 9, -3, -1]

--- a/ride/corkrcrv.json
+++ b/ride/corkrcrv.json
@@ -21,32 +21,23 @@
         },
         "carColours": [
             [
-                [
-                    "light_blue",
-                    "white",
-                    "yellow"
-                ]
+                ["bright_red", "white", "black"]
             ],
             [
-                [
-                    "bright_red",
-                    "yellow",
-                    "yellow"
-                ]
+                ["bordeaux_red", "yellow", "black"]
             ],
             [
-                [
-                    "white",
-                    "bordeaux_red",
-                    "bordeaux_red"
-                ]
+                ["dark_green", "yellow", "black"]
+            ],
+            [
+                ["white", "light_blue", "black"]
             ]
         ],
         "cars": [
             {
                 "rotationFrameMask": 15,
                 "spacing": 261480,
-                "mass": 600,
+                "mass": 525,
                 "numSeats": 4,
                 "numSeatRows": 2,
                 "frictionSoundId": 2,
@@ -72,7 +63,6 @@
                     "corkscrews":4,
                     "restraintAnimation": 4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [
@@ -85,7 +75,7 @@
             {
                 "rotationFrameMask": 15,
                 "spacing": 226616,
-                "mass": 500,
+                "mass": 550,
                 "numSeats": 4,
                 "numSeatRows": 2,
                 "frictionSoundId": 2,
@@ -111,7 +101,6 @@
                     "corkscrews":4,
                     "restraintAnimation": 4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [

--- a/ride/minilady.json
+++ b/ride/minilady.json
@@ -9,22 +9,25 @@
         "category": "rollercoaster",
         "noInversions": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 12,
+        "maxCarsPerTrain": 10,
         "carColours": [
             [
                 ["bright_red", "yellow", "black"]
             ],
             [
-                ["dark_green", "bordeaux_red", "black"]
+                ["bright_green", "bordeaux_red", "black"]
             ],
             [
-                ["yellow", "dark_brown", "black"]
+                ["bright_purple", "yellow", "black"]
+            ],
+            [
+                ["light_orange", "black", "black"]
             ]
         ],
         "cars": {
                 "rotationFrameMask": 15,
                 "spacing": 122024,
-                "mass": 220,
+                "mass": 300,
                 "numSeats": 2,
                 "numSeatRows": 1,
                 "frictionSoundId": 2,

--- a/ride/minilog.json
+++ b/ride/minilog.json
@@ -9,19 +9,19 @@
         "category": "rollercoaster",
         "noInversions": true,
         "minCarsPerTrain": 3,
-        "maxCarsPerTrain": 12,
+        "maxCarsPerTrain": 10,
         "carColours": [
             [
-                ["dark_brown", "black", "black"]
+                ["dark_brown", "dark_green"]
             ],
             [
-                ["saturated_brown", "bordeaux_red", "black"]
+                ["light_brown", "bordeaux_red"]
             ]
         ],
         "cars": {
             "rotationFrameMask": 15,
             "spacing": 122024,
-            "mass": 220,
+            "mass": 300,
             "numSeats": 2,
             "numSeatRows": 1,
             "frictionSoundId": 2,

--- a/ride/minirock.json
+++ b/ride/minirock.json
@@ -14,19 +14,19 @@
         },
         "carColours": [
             [
-                ["grey", "bright_red", "bordeaux_red"]
+                ["grey", "bright_red", "black"]
             ],
             [
-                ["grey", "yellow", "saturated_brown"]
+                ["grey", "yellow", "black"]
             ],
             [
                 ["bright_red", "yellow", "black"]
             ]
         ],
         "cars": {
-            "rotationFrameMask": 31,
+            "rotationFrameMask": 15,
             "spacing": 322492,
-            "mass": 790,
+            "mass": 750,
             "numSeats": 4,
             "numSeatRows": 2,
             "frictionSoundId": 2,
@@ -46,7 +46,6 @@
                 "slopes12Banked22":4,
                 "slopes8Banked22":4
             },
-            "hasAdditionalColour2": true,
             "hasAdditionalColour1": true,
             "hasScreamingRiders": true,
             "loadingPositions": [4, -4, 4, -4]

--- a/ride/rct1.ride.horses/object.json
+++ b/ride/rct1.ride.horses/object.json
@@ -22,7 +22,7 @@
             ]
         ],
         "cars": {
-            "rotationFrameMask": 31,
+            "rotationFrameMask": 15,
             "spacing": 244048,
             "mass": 800,
             "numSeats": 2,

--- a/ride/rct1aa.ride.gtc/object.json
+++ b/ride/rct1aa.ride.gtc/object.json
@@ -50,7 +50,7 @@
                 "loadingPositions": [3, -3]
             },
             {
-                "rotationFrameMask": 31,
+                "rotationFrameMask": 3,
                 "spacing": 34864,
                 "poweredAcceleration": 80,
                 "poweredMaxSpeed": 9,

--- a/ride/steelrc.json
+++ b/ride/steelrc.json
@@ -35,7 +35,7 @@
                 "mass": 550,
                 "numSeats": 4,
                 "numSeatRows": 2,
-                "frictionSoundId": 0,
+                "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual":0,
                 "drawOrder": 5,
@@ -68,7 +68,7 @@
                 "mass": 525,
                 "numSeats": 4,
                 "numSeatRows": 2,
-                "frictionSoundId": 0,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 7,
                 "spriteGroups":{

--- a/ride/steelrcrv.json
+++ b/ride/steelrcrv.json
@@ -35,7 +35,7 @@
                 "mass": 550,
                 "numSeats": 4,
                 "numSeatRows": 2,
-                "frictionSoundId": 0,
+                "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual":0,
                 "drawOrder": 5,
@@ -68,7 +68,7 @@
                 "mass": 525,
                 "numSeats": 4,
                 "numSeatRows": 2,
-                "frictionSoundId": 0,
+                "frictionSoundId": 2,
                 "soundRange": 0,
                 "drawOrder": 7,
                 "spriteGroups":{

--- a/ride/woodtrc.json
+++ b/ride/woodtrc.json
@@ -7,7 +7,7 @@
     "properties": {
         "type": "wooden_rc",
         "category": "rollercoaster",
-        "minCarsPerTrain": 6,
+        "minCarsPerTrain": 3,
         "maxCarsPerTrain": 12,
         "defaultCar": 1,
         "headCars": 0,
@@ -20,10 +20,13 @@
                 ["dark_green", "bordeaux_red", "black"]
             ],
             [
-                ["bordeaux_red", "dark_brown", "yellow"]
+                ["yellow", "bordeaux_red", "black"]
             ],
             [
-                ["dark_brown", "black", "bordeaux_red"]
+                ["dark_brown", "black", "black"]
+            ],
+            [
+                ["bright_red", "dark_brown", "black"]
             ]
         ],
         "cars": [
@@ -33,7 +36,7 @@
                 "mass": 350,
                 "numSeats": 2,
                 "numSeatRows": 1,
-                "frictionSoundId": 54,
+                "frictionSoundId": 1,
                 "soundRange": 2,
                 "effectVisual": 10,
                 "drawOrder": 6,
@@ -52,7 +55,6 @@
                     "slopes8Banked22":4,
                     "restraintAnimation": 4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [5, 3, -7, -9]
@@ -63,7 +65,7 @@
                 "mass": 290,
                 "numSeats": 2,
                 "numSeatRows": 1,
-                "frictionSoundId": 54,
+                "frictionSoundId": 1,
                 "soundRange": 1,
                 "drawOrder": 8,
                 "spriteGroups":{
@@ -81,7 +83,6 @@
                     "slopes8Banked22":4,
                     "restraintAnimation": 4
                 },
-                "hasAdditionalColour2": true,
                 "hasAdditionalColour1": true,
                 "hasScreamingRiders": true,
                 "loadingPositions": [7, 9, -3, -1]


### PR DESCRIPTION
A bunch of metadata assorted fixes for many of the objects already currently in the repo to make them more accurate to the rct1 vehicles and fix some issues with them.
For the max cars per train i've decided to keep them consistent with the rct2 counterparts to the trains just for the sake of parity across rct1 & rct2 trains. 

General:
Removed the third remaps from all vehicles.
Set rotationFrameMask to 15 (or 3 for invisible cars) on all vehicles that didn't already have it set to that.
Set mass values to their rct1 values on all rides that had incorrect values.
Added rct1 default car colors to all rides.

Fixed ids of:
rct1aa.ride.bmsd (was rctaa.ride.bmsd)
rct1aa.ride.bmsu (was rct1.ride.bmsu)

Fixed max cars per train of:
rct1.ride.minilady
rct1.ride.minilog

Fixed min cars per train of:
rct1aa.ride.woodtrc
rct1aa.ride.bmsd
rct1aa.ride.bmsu
rct1aa.ride.bmrb

Fixed friction sound ids of:
rct1.ride.steelrc (was using a chain lift sound)
rct1.ride.steelrcrv (was using a chain lift sound)
rct1aa.ride.woodtrc (was using rct2's wooden coaster sound)
rct1aa.ride.bmfl (was using rct2's b&m sound)
rct1aa.ride.bmsd (was using rct2's b&m sound)
rct1aa.ride.bmsu (was using rct2's b&m sound)
rct1aa.ride.bmrb (was using rct2's b&m sound)