### PR TITLE
Update corkrc maxCarsPerTrain to 8

### DIFF
--- a/ride/corkrc.json
+++ b/ride/corkrc.json
@@ -9,7 +9,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 2,
-        "maxCarsPerTrain": 7,
+        "maxCarsPerTrain": 8,
         "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,

--- a/ride/corkrcrv.json
+++ b/ride/corkrcrv.json
@@ -12,7 +12,7 @@
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
         "minCarsPerTrain": 2,
-        "maxCarsPerTrain": 7,
+        "maxCarsPerTrain": 8,
         "numEmptyCars": 1,
         "defaultCar": 1,
         "tailCars": 0,


### PR DESCRIPTION
RCT1 allowed 8 cars per train for the Corkscrew Roller Coaster's trains. The limit of 7 was only introduced in RCT2 vanilla