### PR TITLE
Fix corkscrew cars

### DIFF
--- a/ride/corkrc.json
+++ b/ride/corkrc.json
@@ -8,9 +8,8 @@
         "type": "corkscrew_rc",
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
-        "minCarsPerTrain": 2,
+        "minCarsPerTrain": 1,
         "maxCarsPerTrain": 8,
-        "numEmptyCars": 1,
         "defaultCar": 1,
         "headCars": 0,
         "ratingMultipler": {

--- a/ride/corkrcrv.json
+++ b/ride/corkrcrv.json
@@ -11,9 +11,8 @@
         "type": "corkscrew_rc",
         "category": "rollercoaster",
         "limitAirTimeBonus": true,
-        "minCarsPerTrain": 2,
+        "minCarsPerTrain": 1,
         "maxCarsPerTrain": 8,
-        "numEmptyCars": 1,
         "defaultCar": 1,
         "tailCars": 0,
         "ratingMultipler": {


### PR DESCRIPTION
Removes the numEmptyCars property as there are no empty cars for these trains and sets the min cars per train to 1 on both of them as that's what it is in rct1.