### PR TITLE
Set woodtrc second car's flatbanked22 to 8 frames

### DIFF
--- a/ride/rct1aa.ride.woodtrc/object.json
+++ b/ride/rct1aa.ride.woodtrc/object.json
@@ -77,7 +77,7 @@
                     "slopes8":4,
                     "slopes16":4,
                     "slopes50":4,
-                    "flatBanked22":4,
+                    "flatBanked22":8,
                     "flatBanked45":16,
                     "slopes12Banked22":16,
                     "slopes8Banked22":4,


### PR DESCRIPTION
Fixes the second car not having the proper number of flatbanked22 frames which was causing visual issues.