### PR TITLE
Update legacy vehicle entry flags from mswing

### DIFF
--- a/ride/rct1.ride.mswing/object.json
+++ b/ride/rct1.ride.mswing/object.json
@@ -36,8 +36,8 @@
                 "slopes25":4,
                 "restraintAnimation": 4
             },
-            "VEHICLE_ENTRY_FLAG_SWINGING": true,
-            "VEHICLE_ENTRY_FLAG_RIDERS_SCREAM": true,
+            "hasSwinging": true,
+            "hasScreamingRiders": true,
             "loadingPositions": [1]
         },
         "buildMenuPriority": 2


### PR DESCRIPTION
I forgot to update the legacy vehicle entry flags to the proper modern ones when i was updating this old port of it i made a year or so ago.
So this just simply updates the flags to use their modern counterparts.