### PR TITLE
Optimize Invisible Car Sprites

### DIFF
--- a/ride/rct1.ride.ctcar/object.json
+++ b/ride/rct1.ride.ctcar/object.json
@@ -45,14 +45,14 @@
                 "loadingPositions": [3, -3]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 70,
                 "poweredMaxSpeed": 7,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
@@ -107,9 +107,6 @@
         "$CSG[40348]",
         "$CSG[40352]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "noCsgImages": [
@@ -172,9 +169,6 @@
         "$RCT2:OBJDATA/CTCAR.DAT[195]",
         "$RCT2:OBJDATA/CTCAR.DAT[203]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1.ride.rcr/object.json
+++ b/ride/rct1.ride.rcr/object.json
@@ -48,14 +48,14 @@
                 "loadingPositions": [0]
             },
             {
-                "rotationFrameMask": 4,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 110,
                 "poweredMaxSpeed": 9,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
@@ -110,9 +110,6 @@
         "$CSG[33352]",
         "$CSG[33356]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "noCsgImages": [
@@ -175,9 +172,6 @@
         "$RCT2:OBJDATA/RCR.DAT[195]",
         "$RCT2:OBJDATA/RCR.DAT[203]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1.ride.spcar/object.json
+++ b/ride/rct1.ride.spcar/object.json
@@ -42,14 +42,14 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 90,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
@@ -100,9 +100,6 @@
         "$CSG[33288]",
         "$CSG[33292]",
 
-        "",
-        "",
-        "",
         ""
     ],
     "noCsgImages": [
@@ -165,9 +162,6 @@
         "$RCT2:OBJDATA/SPCAR.DAT[195]",
         "$RCT2:OBJDATA/SPCAR.DAT[203]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1.ride.truck/object.json
+++ b/ride/rct1.ride.truck/object.json
@@ -47,14 +47,14 @@
                 "loadingPositions": [4]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 80,
                 "poweredMaxSpeed": 8,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
@@ -135,9 +135,6 @@
         "$CSG[33441]",
         "$CSG[33444]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "noCsgImages": [
@@ -204,9 +201,6 @@
 
         "$RCT2:OBJDATA/TRUCK1.DAT[223..234]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1.ride.wmmine/object.json
+++ b/ride/rct1.ride.wmmine/object.json
@@ -50,14 +50,14 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 1,
                 "soundRange": 0,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat": 4
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
@@ -271,9 +271,6 @@
         "$CSG[30692]",
         "$CSG[30692]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1.ride.wmouse/object.json
+++ b/ride/rct1.ride.wmouse/object.json
@@ -51,14 +51,14 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 1,
                 "soundRange": 0,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat": 4
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
@@ -272,9 +272,6 @@
         "$CSG[30532]",
         "$CSG[30532]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1aa.ride.gtc/object.json
+++ b/ride/rct1aa.ride.gtc/object.json
@@ -50,14 +50,14 @@
                 "loadingPositions": [3, -3]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 80,
                 "poweredMaxSpeed": 9,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "isPoweredRideWithUnrestrictedGravity": true,
                 "hasNoUpstopWheels": true,
@@ -114,9 +114,6 @@
         "$CSG[40413]",
         "$CSG[40417]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "noCsgImages": [
@@ -179,9 +176,6 @@
         "$RCT2:OBJDATA/GTC.DAT[195]",
         "$RCT2:OBJDATA/GTC.DAT[203]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1aa.ride.helicar/object.json
+++ b/ride/rct1aa.ride.helicar/object.json
@@ -55,14 +55,14 @@
                 "loadingPositions": [3, -3]
             },
             {
-                "rotationFrameMask": 4,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 40,
                 "poweredMaxSpeed": 5,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
@@ -103,9 +103,6 @@
         "$CSG[33213..33216]",
         "$CSG[33225..33228]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1aa.ride.smouse/object.json
+++ b/ride/rct1aa.ride.smouse/object.json
@@ -71,14 +71,14 @@
                 "loadingPositions": [7, 9, -3, -1]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
@@ -230,9 +230,6 @@
         "$CSG[18733]",
         "$CSG[18741]",
 
-        "",
-        "",
-        "",
         ""
     ],
     "strings": {

--- a/ride/rct1aa.ride.spboat/object.json
+++ b/ride/rct1aa.ride.spboat/object.json
@@ -54,7 +54,7 @@
                 "loadingPositions": [14, 12, 14, 12, 6, 4, 6, 4, -6, -4, -6, -4, -14, -12, -14, -12]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 87160,
                 "soundRange": 0,
                 "poweredAcceleration": 255,
@@ -63,7 +63,7 @@
                 "effectVisual": 13,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "isPowered": true,
                 "hasScreamingRiders": true,
@@ -76,9 +76,6 @@
         "",
         "",
         "$CSG[33657..34088]",
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1aa.ride.vcr/object.json
+++ b/ride/rct1aa.ride.vcr/object.json
@@ -47,14 +47,14 @@
                 "loadingPositions": [4, -4]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 34864,
                 "poweredAcceleration": 60,
                 "poweredMaxSpeed": 7,
                 "carVisual": 1,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "isPowered": true
             }
@@ -109,9 +109,6 @@
         "$CSG[32872]",
         "$CSG[32876]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "noCsgImages": [
@@ -174,9 +171,6 @@
         "$RCT2:OBJDATA/VCR.DAT[195]",
         "$RCT2:OBJDATA/VCR.DAT[203]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {

--- a/ride/rct1ll.ride.cstboat/object.json
+++ b/ride/rct1ll.ride.cstboat/object.json
@@ -58,14 +58,14 @@
                 "loadingPositions": [7, 9, 2, 4, -3, -1]
             },
             {
-                "rotationFrameMask": 3,
+                "rotationFrameMask": 0,
                 "spacing": 87160,
                 "frictionSoundId": 2,
                 "soundRange": 2,
                 "carVisual": 8,
                 "drawOrder": 8,
                 "spriteGroups": {
-                    "slopeFlat":4
+                    "slopeFlat":1
                 },
                 "hasScreamingRiders": true
             }
@@ -415,9 +415,6 @@
 
         "$CSG[31773..31788]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "noCsgImages": [
@@ -904,9 +901,6 @@
 
         "$RCT2:OBJDATA/CSTBOAT.DAT[1715..1730]",
 
-		"",
-		"",
-		"",
 		""
     ],
     "strings": {


### PR DESCRIPTION
As the rotation frames refactor branch can now handle sprite precision values lower than 4, we can reduce the amount of invisible sprites used by all of the cars down to just 1.
This implements that for (hopefully) all of the cars with invisible sprites which will reduce the total sprite count of them by 36.
This applies to both the main images and no csg fallback images.