### PR TITLE
Finalize steel mini trains

### DIFF
--- a/ride/rct1.ride.minilady/object.json
+++ b/ride/rct1.ride.minilady/object.json
@@ -52,7 +52,7 @@
                 "hasScreamingRiders": true,
                 "loadingPositions": [2, 4]
             },
-        "buildMenuPriority": 3
+        "buildMenuPriority": 4
     },
     "images": [
         { "path": "images/preview.png", "format": "raw" },

--- a/ride/rct1.ride.minilog/object.json
+++ b/ride/rct1.ride.minilog/object.json
@@ -46,7 +46,7 @@
             "hasScreamingRiders": true,
             "loadingPositions": [2, 4]
         },
-        "buildMenuPriority": 2
+        "buildMenuPriority": 3
     },
     "images": [
         { "path": "images/preview.png", "format": "raw" },

--- a/ride/rct1.ride.minirock/object.json
+++ b/ride/rct1.ride.minirock/object.json
@@ -9,9 +9,6 @@
         "category": "rollercoaster",
         "minCarsPerTrain": 1,
         "maxCarsPerTrain": 3,
-        "ratingMultipler": {
-            "excitement": 5
-        },
         "carColours": [
             [
                 ["grey", "bright_red", "black"]


### PR DESCRIPTION
Removes the ratingmultiplier field from the rocket cars as the rct1 rocket cars don't seem to have a ratingmultiplier from the testing i've done.
Tweaks the buildmenupriority values of the ladybird & log trains for future proofing for when the spinning cars are added.

The only thing that may need to be changed after this is the object name/id as mentioned in #56 