### PR TITLE
Make default streamlined third colors dark blue

### DIFF
--- a/ride/rct1.ride.streamlined_monorail_trains/object.json
+++ b/ride/rct1.ride.streamlined_monorail_trains/object.json
@@ -23,28 +23,28 @@
                 [
                     "white",
                     "bright_red",
-                    "black"
+                    "dark_blue"
                 ]
             ],
             [
                 [
                     "white",
                     "yellow",
-                    "black"
+                    "dark_blue"
                 ]
             ],
             [
                 [
                     "bordeaux_red",
                     "yellow",
-                    "black"
+                    "dark_blue"
                 ]
             ],
             [
                 [
                     "black",
                     "bright_red",
-                    "black"
+                    "dark_blue"
                 ]
             ]
         ],


### PR DESCRIPTION
Needed for fallback sprites to look better, as the rct2 counterpart to this vehicle uses the third color for it's windows when it's a non-recolorable dark blue in rct1
The third color still does not show up in the coloring window, this just makes their default value when selecting the cars dark blue so they look right when using fallbacks.