### PR TITLE
Remove rating multipliers from some vehicles

### DIFF
--- a/ride/rct1.ride.corkscrew_trains/object.json
+++ b/ride/rct1.ride.corkscrew_trains/object.json
@@ -13,9 +13,6 @@
         "maxCarsPerTrain": 8,
         "defaultCar": 1,
         "headCars": 0,
-        "ratingMultipler": {
-            "intensity": 10
-        },
         "carColours": [
             [
                 ["bright_red", "white", "black"]

--- a/ride/rct1aa.ride.wooden_articulated_trains/object.json
+++ b/ride/rct1aa.ride.wooden_articulated_trains/object.json
@@ -15,10 +15,6 @@
         "maxCarsPerTrain": 12,
         "defaultCar": 1,
         "headCars": 0,
-        "ratingMultipler": {
-            "excitement": 4,
-            "nausea": 2
-        },
         "carColours": [
             [
                 [


### PR DESCRIPTION
Oddly enough these trains don't seem to have had rating multipliers in RCT1.
"Corkscrew" from the RCT1 base game's pre-built tracks in RCT1 and in open after this change.
![Screenshot_select-area_20221019100933](https://user-images.githubusercontent.com/42477864/196718435-070255c4-8f9d-4e32-95bb-d3eaef249759.png)
![Screenshot_select-area_20221019100941](https://user-images.githubusercontent.com/42477864/196718436-5caeafc9-cd9b-49cd-9d23-09db010879f3.png)
"Wood Twister 1" from AA's pre-built tracks in RCT1 and in open after this change.
![Screenshot_select-area_20221020145838](https://user-images.githubusercontent.com/42477864/197035543-13c5617f-0254-490f-83b8-72383e84f7e7.png)
![Screenshot_select-area_20221020145846](https://user-images.githubusercontent.com/42477864/197035546-fb971a6d-fa6f-422d-b0b3-5612196ce622.png)
