### PR TITLE
Remove excitement multiplier from racing cars

### DIFF
--- a/ride/rct1.ride.racing_cars/object.json
+++ b/ride/rct1.ride.racing_cars/object.json
@@ -16,7 +16,7 @@
         "headCars": 1,
         "tailCars": 1,
         "ratingMultipler": {
-            "excitement": 3
+            "excitement": 1
         },
         "carColours": [
             [

--- a/ride/rct1.ride.racing_cars/object.json
+++ b/ride/rct1.ride.racing_cars/object.json
@@ -15,9 +15,6 @@
         "tabCar": 1,
         "headCars": 1,
         "tailCars": 1,
-        "ratingMultipler": {
-            "excitement": 1
-        },
         "carColours": [
             [
                 ["bright_green", "yellow", "black"]


### PR DESCRIPTION
After some further testing it doesn't seem to have had any rating multipliers at all in RCT1, the car ride's base excitement rating value in RCT1 is 1.95 rather than 2.00 like it is in (Open)RCT2 and removing the excitement multiplier from them makes the stats match perfectly.

![Screenshot_select-area_20221122143758](https://user-images.githubusercontent.com/42477864/203444528-27221501-d87b-41a3-b624-6524fe6a456e.png)
![Screenshot_select-area_20221122185243](https://user-images.githubusercontent.com/42477864/203444535-f7084e9a-0bc4-45ff-bf3f-3d0601877671.png)